### PR TITLE
feat: use value objects to validate values

### DIFF
--- a/src/csv.rs
+++ b/src/csv.rs
@@ -47,7 +47,7 @@ mod test {
     fn serialize_single_record() {
         let date =
             NaiveDateTime::parse_from_str("2025-07-22 13:24:35", "%Y-%m-%d %H:%M:%S").unwrap();
-        let record = TaxerRecord::new("3141592600", date, 220394.05, "Послуги з розробки");
+        let record = TaxerRecord::new_unchecked("3141592600", date, 220394.05, "Послуги з розробки");
 
         let buf = vec![];
         let mut w = BufWriter::new(buf);
@@ -58,7 +58,7 @@ mod test {
         let raw_csv = String::from_utf8(buf).unwrap();
         assert_eq!(
             raw_csv,
-            "3141592600,22.07.2025 13:24:35,220394.05,Послуги з розробки,,,,\n"
+            "3141592600,22.07.2025 13:24:35,220394.05,Послуги з розробки,,,,UAH\n"
         );
     }
 
@@ -69,7 +69,7 @@ mod test {
         let record = TaxerRecord::builder()
             .tax_code("2121049841")
             .date(date)
-            .amount(220394.05)
+            .amount_raw(220394.05).unwrap()
             .comment("Послуги з розробки")
             .operation("Дохід")
             .income_type("Основний дохід")

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -42,12 +42,15 @@ mod test {
     use chrono::NaiveDateTime;
 
     use crate::TaxerRecord;
+    use crate::value::{Amount, TaxCode};
 
     #[test]
     fn serialize_single_record() {
         let date =
             NaiveDateTime::parse_from_str("2025-07-22 13:24:35", "%Y-%m-%d %H:%M:%S").unwrap();
-        let record = TaxerRecord::new_unchecked("3141592600", date, 220394.05, "Послуги з розробки");
+        let tax_code = TaxCode::new("3141592600").unwrap();
+        let amount = Amount::new(220394.05).unwrap();
+        let record = TaxerRecord::new(tax_code, date, amount, "Послуги з розробки");
 
         let buf = vec![];
         let mut w = BufWriter::new(buf);
@@ -67,9 +70,11 @@ mod test {
         let date =
             NaiveDateTime::parse_from_str("2025-07-22 13:24:35", "%Y-%m-%d %H:%M:%S").unwrap();
         let record = TaxerRecord::builder()
-            .tax_code("2121049841")
+            .tax_code_raw("2121049841")
+            .unwrap()
             .date(date)
-            .amount_raw(220394.05).unwrap()
+            .amount_raw(220394.05)
+            .unwrap()
             .comment("Послуги з розробки")
             .operation("Дохід")
             .income_type("Основний дохід")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod csv;
 pub mod record;
+pub mod value;
 
 pub use csv::serialize_taxer;
 pub use record::TaxerRecord;

--- a/src/record.rs
+++ b/src/record.rs
@@ -78,9 +78,14 @@ impl TaxerRecordBuilder {
         self
     }
 
-    pub fn tax_code_raw(mut self, tax_code: impl Into<String>) -> Result<TaxerRecordBuilder, InvalidRecord> {
+    pub fn tax_code_raw(
+        mut self,
+        tax_code: impl Into<String>,
+    ) -> Result<TaxerRecordBuilder, InvalidRecord> {
         let raw_code = tax_code.into();
-        self.tax_code = Some(TaxCode::new(raw_code).map_err(|e| InvalidRecord::InvalidTaxCode(e.invalid_code))?);
+        self.tax_code = Some(
+            TaxCode::new(raw_code).map_err(|e| InvalidRecord::InvalidTaxCode(e.invalid_code))?,
+        );
         Ok(self)
     }
     pub fn date(mut self, date: NaiveDateTime) -> Self {
@@ -93,7 +98,8 @@ impl TaxerRecordBuilder {
     }
 
     pub fn amount_raw(mut self, amount: f64) -> Result<Self, InvalidRecord> {
-        self.amount = Some(Amount::new(amount).map_err(|_| InvalidRecord::InvalidAmount(amount))?);
+        self.amount =
+            Some(Amount::new(amount).map_err(|e| InvalidRecord::InvalidAmount(e.invalid_amount))?);
         Ok(self)
     }
     pub fn comment(mut self, comment: impl Into<String>) -> Self {

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,8 +2,8 @@
 //!
 //! Records are composed of those object to prevent accepting invalid values.
 
-use std::cmp::Ordering;
 use serde::Serialize;
+use std::cmp::Ordering;
 use thiserror::Error;
 
 const MAX_AMOUNT: f64 = 10000000.;
@@ -30,7 +30,9 @@ impl Amount {
     pub fn new(raw: f64) -> Result<Self, AmountError> {
         let acceptable_amounts = 0.01..MAX_AMOUNT;
         if !acceptable_amounts.contains(&raw) {
-            return Err(AmountError {invalid_amount: raw});
+            return Err(AmountError {
+                invalid_amount: raw,
+            });
         }
         Ok(Amount(raw))
     }
@@ -68,12 +70,12 @@ impl TaxCode {
     pub fn new(raw: impl Into<String>) -> Result<Self, TaxCodeError> {
         let raw = raw.into();
         if raw.len() != 8 && raw.len() != 10 {
-            return Err(TaxCodeError { invalid_code: raw.to_string() });
+            return Err(TaxCodeError { invalid_code: raw });
         }
         if raw.chars().any(|c| !c.is_ascii_digit()) {
-            return Err(TaxCodeError { invalid_code: raw.to_string() });
+            return Err(TaxCodeError { invalid_code: raw });
         }
-        Ok(TaxCode(raw.to_string()))
+        Ok(TaxCode(raw))
     }
 
     pub fn into_inner(self) -> String {
@@ -126,7 +128,6 @@ mod tests {
     #[test]
     fn reject_amounts_out_of_bounds() {
         // Less than minimum
-        assert!(Amount::new(0.0).is_err());
         assert!(Amount::new(-1.0).is_err());
         assert!(Amount::new(-100.0).is_err());
         // Equal to minimum bound (exclusive)

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,85 @@
+//! Reusable validated value objects.
+//!
+//! Records are composed of those object to prevent accepting invalid values.
+
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use serde::Serialize;
+use thiserror::Error;
+
+const MAX_AMOUNT: f64 = 10000000.;
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize)]
+pub struct Amount(f64);
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TaxCode(String);
+
+#[derive(Debug, Clone, Error)]
+#[error("invalid amount {invalid_amount}")]
+pub struct AmountError {
+    pub invalid_amount: f64,
+}
+
+#[derive(Debug, Clone, Error)]
+#[error("valid tax code must be 8 or 10 digits {invalid_code}")]
+pub struct TaxCodeError {
+    pub invalid_code: String,
+}
+
+impl Amount {
+    pub fn new(raw: f64) -> Result<Self, AmountError> {
+        let acceptable_amounts = 0.01..MAX_AMOUNT;
+        if !acceptable_amounts.contains(&raw) {
+            return Err(AmountError {invalid_amount: raw});
+        }
+        Ok(Amount(raw))
+    }
+
+    pub fn raw(&self) -> f64 {
+        self.0
+    }
+}
+
+impl Eq for Amount {}
+impl PartialOrd for Amount {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Amount {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.partial_cmp(&other.0) {
+            Some(ordering) => ordering,
+            None => unreachable!(),
+        }
+    }
+}
+
+impl TryFrom<f64> for Amount {
+    type Error = AmountError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Amount::new(value)
+    }
+}
+
+impl TaxCode {
+    pub fn new(raw: Cow<String>) -> Result<Self, TaxCodeError> {
+        if raw.len() != 8 && raw.len() != 10 {
+            return Err(TaxCodeError { invalid_code: raw.to_string() });
+        }
+        Ok(TaxCode(raw.to_string()))
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for TaxCode {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,7 +2,6 @@
 //!
 //! Records are composed of those object to prevent accepting invalid values.
 
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use serde::Serialize;
 use thiserror::Error;
@@ -66,8 +65,12 @@ impl TryFrom<f64> for Amount {
 }
 
 impl TaxCode {
-    pub fn new(raw: Cow<String>) -> Result<Self, TaxCodeError> {
+    pub fn new(raw: impl Into<String>) -> Result<Self, TaxCodeError> {
+        let raw = raw.into();
         if raw.len() != 8 && raw.len() != 10 {
+            return Err(TaxCodeError { invalid_code: raw.to_string() });
+        }
+        if raw.chars().any(|c| !c.is_ascii_digit()) {
             return Err(TaxCodeError { invalid_code: raw.to_string() });
         }
         Ok(TaxCode(raw.to_string()))
@@ -81,5 +84,63 @@ impl TaxCode {
 impl AsRef<str> for TaxCode {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_valid_tax_code() {
+        assert!(TaxCode::new("12345678").is_ok());
+        assert!(TaxCode::new("1234567890").is_ok());
+    }
+
+    #[test]
+    fn reject_tax_code_of_invalid_length() {
+        assert!(TaxCode::new("123").is_err());
+        assert!(TaxCode::new("").is_err());
+        assert!(TaxCode::new("12345678901").is_err());
+        assert!(TaxCode::new("123456789").is_err());
+        assert!(TaxCode::new("1234567").is_err());
+    }
+
+    #[test]
+    fn reject_tax_code_of_non_digits() {
+        assert!(TaxCode::new("1234567a").is_err());
+        assert!(TaxCode::new("1234 567").is_err());
+        assert!(TaxCode::new("1234-56789").is_err());
+        assert!(TaxCode::new("-123456789").is_err());
+        assert!(TaxCode::new("x123456789").is_err());
+    }
+
+    #[test]
+    fn accept_valid_amount() {
+        assert!(Amount::new(0.01).is_ok());
+        assert!(Amount::new(1.0).is_ok());
+        assert!(Amount::new(9999999.99).is_ok());
+        assert!(Amount::new(MAX_AMOUNT - 0.01).is_ok());
+    }
+
+    #[test]
+    fn reject_amounts_out_of_bounds() {
+        // Less than minimum
+        assert!(Amount::new(0.0).is_err());
+        assert!(Amount::new(-1.0).is_err());
+        assert!(Amount::new(-100.0).is_err());
+        // Equal to minimum bound (exclusive)
+        assert!(Amount::new(0.0).is_err());
+        // Equal to or greater than max bound
+        assert!(Amount::new(MAX_AMOUNT).is_err());
+        assert!(Amount::new(MAX_AMOUNT + 1.0).is_err());
+        assert!(Amount::new(1e12).is_err());
+    }
+
+    #[test]
+    fn reject_amounts_special_cases() {
+        assert!(Amount::new(f64::NAN).is_err());
+        assert!(Amount::new(f64::INFINITY).is_err());
+        assert!(Amount::new(f64::NEG_INFINITY).is_err());
     }
 }


### PR DESCRIPTION
This PR adds value objects for tax codes and amounts. It is done for the validation purposes.
With the value objects it is impossible to create values that Taxer can't process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced validated value types for tax codes and amounts, ensuring only properly formatted values are accepted.
  * Added clear error messages for invalid tax codes and amounts.
  * Exposed a new module for value types to enhance external usage.

* **Refactor**
  * Enhanced record creation and builder processes to use these new validated types, improving data integrity and error reporting.
  * Updated serialization format to include currency code in CSV outputs.

* **Bug Fixes**
  * Improved validation prevents invalid or out-of-range values from being accepted in records.

* **Tests**
  * Expanded unit tests to cover new validation logic for tax codes and amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->